### PR TITLE
Do not expose device IDs any longer

### DIFF
--- a/content.js
+++ b/content.js
@@ -71,25 +71,34 @@ var inject = '('+function() {
                 if (sessionStorage.__filterAudioDevices) {
                     devices = devices.filter((device) => device.kind !== 'audioinput');
                 }
-                if (sessionStorage.__filterDeviceLabels
-                    || sessionStorage.__getUserMediaAudioError === 'NotAllowedError'
-                    || sessionStorage.__getUserMediaVideoError === 'NotAllowedError') {
-                    devices = devices.map((device) => {
-                        const deviceWithoutLabel = {
-                            deviceId: '',
-                            kind: device.kind,
-                            label: '',
-                            groupId: device.groupId,
-                        };
 
-                        // Firefox does not empty deviceId
-                        if (navigator.mozGetUserMedia) {
-                            deviceWithoutLabel.deviceId = device.deviceId;
-                        }
+                devices = devices.map((device) => {
+                    const deviceWithoutLabelAndDeviceId = {
+                        deviceId: '',
+                        kind: device.kind,
+                        label: '',
+                        groupId: device.groupId,
+                    };
 
-                        return deviceWithoutLabel;
-                    });
-                }
+                    // Firefox does not like empty deviceId
+                    if (navigator.mozGetUserMedia) {
+                        deviceWithoutLabelAndDeviceId.deviceId = device.deviceId;
+                    }
+
+                    if (device.kind === 'audioinput' && sessionStorage.__getUserMediaAudioError === 'NotAllowedError') {
+                        return deviceWithoutLabelAndDeviceId;
+                    }
+
+                    if (device.kind === 'videoinput' && sessionStorage.__getUserMediaVideoError === 'NotAllowedError') {
+                        return deviceWithoutLabelAndDeviceId;
+                    }
+
+                    if (sessionStorage.__filterDeviceLabels) {
+                        return deviceWithoutLabelAndDeviceId;
+                    }
+
+                    return device;
+                });
                 if (sessionStorage.__fakeVideoDevices) {
                     JSON.parse(sessionStorage.__fakeVideoDevices).forEach(function(fakeDeviceSpec) {
                         devices.push({

--- a/content.js
+++ b/content.js
@@ -60,7 +60,7 @@ var inject = '('+function() {
 
     // override enumerateDevices to filter certain device kinds or return empty labels
     // (which means no permission has been granted). Also returns empty labels
-    // when getUserMedia permission is denied via a session storage flag.
+    // and device ids when getUserMedia permission is denied via a session storage flag.
     var origEnumerateDevices = navigator.mediaDevices.enumerateDevices.bind(navigator.mediaDevices);
     navigator.mediaDevices.enumerateDevices = function() {
         return origEnumerateDevices()
@@ -75,12 +75,18 @@ var inject = '('+function() {
                     || sessionStorage.__getUserMediaAudioError === 'NotAllowedError'
                     || sessionStorage.__getUserMediaVideoError === 'NotAllowedError') {
                     devices = devices.map((device) => {
-                        var deviceWithoutLabel = {
-                            deviceId: device.deviceId,
+                        const deviceWithoutLabel = {
+                            deviceId: '',
                             kind: device.kind,
                             label: '',
                             groupId: device.groupId,
                         };
+
+                        // Firefox does not empty deviceId
+                        if (navigator.mozGetUserMedia) {
+                            deviceWithoutLabel.deviceId = device.deviceId;
+                        }
+
                         return deviceWithoutLabel;
                     });
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,6 @@
   "content_scripts": [ {
     "js": [ "content.js" ],
     "run_at": "document_start",
-    "matches": [ "https://*/*", "http://localhost:9876/*" ]
+    "matches": [ "https://*/*", "http://localhost:*/*" ]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,6 @@
   "version": "1.0.0",
   "manifest_version": 2,
   "minimum_chrome_version": "34",
-  "applications": {
-    "gecko": {
-      "id": "webrtc@rocks"
-    }
-  },
   "icons": {
   },
   "content_scripts": [ {

--- a/test/enumerateDevices.js
+++ b/test/enumerateDevices.js
@@ -32,4 +32,19 @@ describe('enumerateDevices inject', () => {
                 done();
             });
     });
+
+    it('filters device ids when permission is denied (Chrome only)', (done) => {
+        sessionStorage.__getUserMediaAudioError = 'NotAllowedError';
+        navigator.mediaDevices.enumerateDevices()
+            .then((devices) => {
+                const nonEmptyDeviceIds = devices.filter(d => d.deviceId !== '');
+                if (navigator.mozGetUserMedia) {
+                  expect(nonEmptyDeviceIds).not.to.have.length(0);
+                } else {
+                  expect(nonEmptyDeviceIds).to.have.length(0);
+                }
+                done();
+            });
+    });
 });
+

--- a/test/enumerateDevices.js
+++ b/test/enumerateDevices.js
@@ -23,8 +23,8 @@ describe('enumerateDevices inject', () => {
             });
     });
 
-    it('filters device labels when permission is denied', (done) => {
-        sessionStorage.__getUserMediaAudioError = 'NotAllowedError';
+    it('filters device labels when __filterDeviceLabels is set', (done) => {
+        sessionStorage.__filterDeviceLabels = true;
         navigator.mediaDevices.enumerateDevices()
             .then((devices) => {
                 const nonEmptyLabels = devices.filter(d => d.label !== '');
@@ -33,15 +33,49 @@ describe('enumerateDevices inject', () => {
             });
     });
 
-    it('filters device ids when permission is denied (Chrome only)', (done) => {
+    it('filters audio device labels when permission is denied', (done) => {
         sessionStorage.__getUserMediaAudioError = 'NotAllowedError';
         navigator.mediaDevices.enumerateDevices()
             .then((devices) => {
-                const nonEmptyDeviceIds = devices.filter(d => d.deviceId !== '');
+                const audioDevicesWithLabels = devices.filter(d => d.kind === 'audioinput' && d.label !== '');
+                expect(audioDevicesWithLabels).to.have.length(0);
+                done();
+            });
+    });
+
+    it('filters audio device ids when permission is denied (Chrome only)', (done) => {
+        sessionStorage.__getUserMediaAudioError = 'NotAllowedError';
+        navigator.mediaDevices.enumerateDevices()
+            .then((devices) => {
+                const audioDevicesWithDeviceIds = devices.filter(d => d.kind === 'audioinput' && d.deviceId !== '');
                 if (navigator.mozGetUserMedia) {
-                  expect(nonEmptyDeviceIds).not.to.have.length(0);
+                  expect(audioDevicesWithDeviceIds).not.to.have.length(0);
                 } else {
-                  expect(nonEmptyDeviceIds).to.have.length(0);
+                  expect(audioDevicesWithDeviceIds).to.have.length(0);
+                }
+                done();
+            });
+    });
+
+    it('filters video device labels when permission is denied', (done) => {
+        sessionStorage.__getUserMediaVideoError = 'NotAllowedError';
+        navigator.mediaDevices.enumerateDevices()
+            .then((devices) => {
+                const videoDevicesWithLabels = devices.filter(d => d.kind === 'videoinput' && d.label !== '');
+                expect(videoDevicesWithLabels).to.have.length(0);
+                done();
+            });
+    });
+
+    it('filters video device ids when permission is denied (Chrome only)', (done) => {
+        sessionStorage.__getUserMediaVideoError = 'NotAllowedError';
+        navigator.mediaDevices.enumerateDevices()
+            .then((devices) => {
+                const videoDevicesWithDeviceIds = devices.filter(d => d.kind === 'videoinput' && d.deviceId !== '');
+                if (navigator.mozGetUserMedia) {
+                  expect(videoDevicesWithDeviceIds).not.to.have.length(0);
+                } else {
+                  expect(videoDevicesWithDeviceIds).to.have.length(0);
                 }
                 done();
             });


### PR DESCRIPTION
Device IDs are not exposed by `enumerateDevices` if permission to use devices has not been granted.
Reference : https://bugs.chromium.org/p/chromium/issues/detail?id=1019176
This works for Chrome, not for Firefox though.

This PR also modified `manifest.json` to:
- fix "Unrecognized manifest key applications" error
- allow extension to run on any app served by localhost