### PR TITLE
Inject script as soon as possible.

### DIFF
--- a/content.js
+++ b/content.js
@@ -99,10 +99,8 @@ var inject = '('+function() {
     };
 }+')();';
 
-document.addEventListener('DOMContentLoaded', function() {
-    var script = document.createElement('script');
-    script.textContent = inject;
-    var parent = document.head || document.documentElement;
-    parent.insertBefore(script, parent.firstChild);
-    script.parentNode.removeChild(script);
-});
+var script = document.createElement('script');
+script.textContent = inject;
+var parent = document.head || document.documentElement;
+parent.insertBefore(script, parent.firstChild);
+script.parentNode.removeChild(script);


### PR DESCRIPTION
Waiting for the `DOMContentLoaded` event results in running the script too late.

Method 2b in this SF answer ensures we run it before any other script:
https://stackoverflow.com/questions/9515704/use-a-content-script-to-access-the-page-context-variables-and-functions

I successfully tested it with some Opentok applications that were previously ignoring the script injected by this extension.